### PR TITLE
Add PyPI publish workflow and bump version

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,33 @@
+# Publish to PyPI when a new release is created
+# For more information see: https://docs.github.com/en/actions/guides/publishing-python-packages
+
+name: python-publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2025-09-01
+
+### Added
+- **Continuous Deployment**: Introduced GitHub Actions workflow for automated PyPI publishing.
+
 ## [0.3.2] - 2025-09-01
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "piedomains"
-version = "0.3.2"
+version = "0.3.3"
 description = "Predict categories based on domain names and their content"
 readme = "README.rst"
 license = {text = "MIT License"}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish releases to PyPI
- bump project version to 0.3.3 and document release

## Testing
- `pytest piedomains/tests/test_007_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68b621b7205c832f9372cff13da33a1d