### PR TITLE
Fix pandas/numpy compatibility and add test

### DIFF
--- a/piedomains/api.py
+++ b/piedomains/api.py
@@ -12,7 +12,9 @@ import warnings
 from datetime import datetime
 from typing import List, Optional, Union
 
-import pandas as pd
+from .utils import safe_import_pandas
+
+pd = safe_import_pandas()
 
 from .classifiers import CombinedClassifier, ImageClassifier, TextClassifier
 from .logging import get_logger

--- a/piedomains/archive_support.py
+++ b/piedomains/archive_support.py
@@ -5,10 +5,12 @@ Extended API functions that support historical snapshots.
 """
 
 import requests
-import pandas as pd
+from .utils import safe_import_pandas
 from datetime import datetime
 from typing import Union, Optional
 from urllib.parse import quote
+
+pd = safe_import_pandas()
 
 from .piedomain import Piedomain
 from .logging import get_logger

--- a/piedomains/classifiers/combined_classifier.py
+++ b/piedomains/classifiers/combined_classifier.py
@@ -3,9 +3,11 @@
 Combined text and image-based domain classification.
 """
 
-import pandas as pd
+from ..utils import safe_import_pandas
 import numpy as np
 from typing import List, Optional, Dict
+
+pd = safe_import_pandas()
 
 from ..logging import get_logger
 from .text_classifier import TextClassifier

--- a/piedomains/classifiers/image_classifier.py
+++ b/piedomains/classifiers/image_classifier.py
@@ -4,9 +4,11 @@ Image-based domain classification using homepage screenshots.
 """
 
 import os
-import pandas as pd
+from ..utils import safe_import_pandas
 import numpy as np
 from typing import List, Dict, Optional
+
+pd = safe_import_pandas()
 
 from ..base import Base
 from ..constants import classes

--- a/piedomains/classifiers/text_classifier.py
+++ b/piedomains/classifiers/text_classifier.py
@@ -7,10 +7,12 @@ import os
 from typing import Dict, List, Optional, Tuple
 
 import numpy as np
-import pandas as pd
+from ..utils import safe_import_pandas
 
 from ..base import Base
 from ..constants import classes
+pd = safe_import_pandas()
+
 from ..logging import get_logger
 from ..processors.content_processor import ContentProcessor
 

--- a/piedomains/piedomain.py
+++ b/piedomains/piedomain.py
@@ -9,7 +9,9 @@ from selenium import webdriver
 from PIL import Image
 
 import numpy as np
-import pandas as pd
+from .utils import safe_import_pandas
+
+pd = safe_import_pandas()
 import joblib
 
 from .constants import classes, most_common_words

--- a/piedomains/scripts/screenshot.py
+++ b/piedomains/scripts/screenshot.py
@@ -1,10 +1,12 @@
 import os
-import pandas as pd
+from ..utils import safe_import_pandas
 from PIL import Image
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
 from webdriver_manager.chrome import ChromeDriverManager
 
+
+pd = safe_import_pandas()
 
 driver = None
 

--- a/piedomains/utils.py
+++ b/piedomains/utils.py
@@ -2,6 +2,37 @@ import os
 import tarfile
 import requests
 
+def safe_import_pandas():
+    """Safely import pandas with a clear error if it's incompatible.
+
+    Pandas can raise a ``ValueError`` when the installed NumPy version
+    is ABI-incompatible with the version it was built against.  This
+    helper converts that failure into a more informative ``ImportError``
+    so users know how to resolve the issue instead of seeing the cryptic
+    "numpy.dtype size changed" message.
+
+    Returns
+    -------
+    ModuleType
+        The imported :mod:`pandas` module.
+
+    Raises
+    ------
+    ImportError
+        If pandas cannot be imported due to a binary mismatch or other
+        installation problems.
+    """
+    try:  # pragma: no cover - success path exercised in normal tests
+        import pandas as pd
+    except Exception as exc:  # pragma: no cover - handled in dedicated test
+        raise ImportError(
+            "Failed to import pandas. This is typically caused by an"
+            " incompatible NumPy version. Try reinstalling pandas and"
+            " NumPy to ensure they are built against each other."
+        ) from exc
+
+    return pd
+
 
 REPO_BASE_URL = os.environ.get("PIEDOMAINS_MODEL_URL") or "https://dataverse.harvard.edu/api/access/datafile/7081895"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,10 @@ requires-python = ">=3.9"
 dependencies = [
     "tqdm>=4.64.0",
     "beautifulsoup4>=4.10.0",
-    "pandas>=1.5.0,<3.0.0",
+    "pandas>=2.0.0,<3.0.0",
     "nltk>=3.8",
-    "tensorflow>=2.11.1,<2.16.0",
-    "numpy>=1.21.0,<2.0.0",
+    "tensorflow>=2.11.1,<3.0.0",
+    "numpy>=2.0.0,<3.0.0",
     "scikit-learn>=1.3.0,<2.0.0",
     "joblib>=1.2.0",
     "selenium>=4.8.0,<5.0.0",
@@ -70,7 +70,7 @@ piedomains = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["piedomains/tests"]
+testpaths = ["piedomains/tests", "tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]

--- a/requirements_rtd.txt
+++ b/requirements_rtd.txt
@@ -3,7 +3,7 @@
 sphinx>=4.0.0
 sphinx-rtd-theme
 beautifulsoup4>=4.0.0
-pandas>=1.4.0
-numpy>=1.21.0
+pandas>=2.0.0
+numpy>=2.0.0
 requests>=2.20.0
 tqdm>=4.60.0

--- a/streamlit/requirements.txt
+++ b/streamlit/requirements.txt
@@ -1,5 +1,5 @@
 Cython>=0.28.5
-numpy>=1.22.0
+numpy>=2.0.0
 joblib
 tqdm
 nltk
@@ -9,7 +9,8 @@ bs4==0.0.1
 scikit-learn >=1.2.1
 Pillow==10.3.0
 selenium==4.8.0
-pandas==1.4.2
+pandas>=2.0.0
 setuptools>=65.5.1
-piedomains==0.0.18
+piedomains>=0.3.3
 streamlit
+

--- a/tests/test_dependency_checks.py
+++ b/tests/test_dependency_checks.py
@@ -1,0 +1,33 @@
+import builtins
+import importlib.util
+import pathlib
+
+import pytest
+
+UTILS_PATH = pathlib.Path(__file__).resolve().parents[0] / ".." / "piedomains" / "utils.py"
+UTILS_PATH = UTILS_PATH.resolve()
+
+spec = importlib.util.spec_from_file_location("pd_utils", UTILS_PATH)
+pd_utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(pd_utils)
+safe_import_pandas = pd_utils.safe_import_pandas
+
+
+def test_safe_import_pandas_success():
+    pd = safe_import_pandas()
+    df = pd.DataFrame({"a": [1]})
+    assert df.loc[0, "a"] == 1
+
+
+def test_safe_import_pandas_failure(monkeypatch):
+    original_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "pandas":
+            raise ValueError("numpy.dtype size changed")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", mock_import)
+
+    with pytest.raises(ImportError):
+        safe_import_pandas()


### PR DESCRIPTION
## Summary
- add safe_import_pandas helper that surfaces useful error message when pandas fails to import
- require pandas>=2 and numpy>=2
- add regression tests for pandas/numpy compatibility

## Testing
- `pytest tests/test_dependency_checks.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6aabe974c832f82072410a27f0a1f