### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -1,4 +1,6 @@
 name: Windows
+permissions:
+  contents: read
 on: [push, pull_request]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/themains/piedomains/security/code-scanning/16](https://github.com/themains/piedomains/security/code-scanning/16)

To fix the issue, we need to add a `permissions` key at either the workflow root (recommended here, since there is only one job and it does not need elevated privileges) or within the individual job. For a typical Python test job using only `actions/checkout` and running tests, the minimal required permission is usually `contents: read`. This should be added at the root of the workflow YAML, just after the `name` and before `on:` (or directly below `on:`). No other code or configuration changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
