### PR TITLE
Potential fix for code scanning alert no. 18: Incomplete URL substring sanitization

### DIFF
--- a/piedomains/fetchers.py
+++ b/piedomains/fetchers.py
@@ -158,7 +158,7 @@ class ArchiveFetcher(BaseFetcher):
             
             # Remove archive.org specific elements
             for element in soup.find_all(['script', 'link', 'div'], 
-                                       attrs={'src': lambda x: x and 'archive.org' in x}):
+                                       attrs={'src': lambda x: x and (urlparse(x).hostname == 'archive.org')}):
                 element.decompose()
             for element in soup.find_all(attrs={'class': lambda x: x and 'wayback' in str(x).lower()}):
                 element.decompose()


### PR DESCRIPTION
Potential fix for [https://github.com/themains/piedomains/security/code-scanning/18](https://github.com/themains/piedomains/security/code-scanning/18)

To safely and accurately identify archive.org-related resources in HTML, we should properly parse the attributes (like `src`) as URLs and compare their host part against the expected host (`archive.org`). This is more robust than substring checks. The best fix is to replace the substring test `'archive.org' in x` with logic that parses `x` (if present) and removes the element only if its host is "archive.org". You should also account for the possibility that `x` may not be a valid URL; add appropriate error handling, and avoid removal in such cases. Edit only the relevant line(s) (within the for loop removing archive.org-specific elements) and add any required imports (though `urlparse` is already imported).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
