### PR TITLE
Use current Hugging Face Hub API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # Docs
 docs/build
+docs/_build/
 docs/source/_build
 _site/
 _doctest/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     # tensorflow does not, which is why it is gone.
     "torch>=2.6.0",
     "transformers>=5.0.0",
-    "huggingface-hub>=0.23",
+    "huggingface-hub>=1.27.0",
     "safetensors>=0.4.5",
     "litellm>=1.55.0",
     "requests>=2.25.0",

--- a/src/piedomains/api.py
+++ b/src/piedomains/api.py
@@ -32,15 +32,16 @@ class DomainClassifier:
 
     Example (Traditional ML):
         >>> classifier = DomainClassifier()
-        >>> results = classifier.classify(["google.com", "facebook.com"])
-        >>> for result in results:
+        >>> run = classifier.classify(["google.com", "facebook.com"])
+        >>> for result in run["results"]:
         ...     print(f"{result['domain']}: {result['category']} ({result['confidence']:.3f})")
         google.com: search (0.892)
         facebook.com: socialnet (0.967)
 
         # Historical analysis
-        >>> results = classifier.classify(["google.com"], archive_date="20200101")
-        >>> print(f"Archive: {results[0]['category']} from {results[0]['date_time_collected']}")
+        >>> run = classifier.classify(["google.com"], archive_date="20200101")
+        >>> result = run["results"][0]
+        >>> print(f"Archive: {result['category']} from {result['date_time_collected']}")
 
     Example (LLM-based):
         >>> classifier = DomainClassifier()
@@ -61,7 +62,8 @@ class DomainClassifier:
         >>> # Same collected content, different classification approaches
 
     JSON Output Schema:
-        All classification methods return List[Dict] with consistent structure:
+        The core classification methods return a dictionary containing ``results``
+        and a run ``report``. Each row in ``results`` has a consistent structure:
 
         Collection Data Schema (from collect_content)::
 
@@ -351,7 +353,7 @@ class DomainClassifier:
             latest: Whether to download latest model versions (default: False)
 
         Returns:
-            list[dict]: Text classification results in JSON format with fields:
+            dict: ``{"results": [...], "report": {...}}``. Result rows contain:
                 - url: Original URL/domain input
                 - domain: Parsed domain name
                 - text_path: Path to collected HTML file
@@ -366,8 +368,9 @@ class DomainClassifier:
 
         Example:
             >>> classifier = DomainClassifier()
-            >>> results = classifier.classify_by_text(["wikipedia.org"])
-            >>> print(f"{results[0]['domain']}: {results[0]['category']} ({results[0]['confidence']:.3f})")
+            >>> run = classifier.classify_by_text(["wikipedia.org"])
+            >>> result = run["results"][0]
+            >>> print(f"{result['domain']}: {result['category']} ({result['confidence']:.3f})")
             wikipedia.org: education (0.823)
         """
         return self._run(domains, "text", archive_date, use_cache, latest)
@@ -391,7 +394,7 @@ class DomainClassifier:
             latest: Whether to download latest model versions (default: False)
 
         Returns:
-            list[dict]: Image classification results in JSON format with fields:
+            dict: ``{"results": [...], "report": {...}}``. Result rows contain:
                 - url: Original URL/domain input
                 - domain: Parsed domain name
                 - text_path: Path to collected HTML file (may be None)
@@ -406,8 +409,9 @@ class DomainClassifier:
 
         Example:
             >>> classifier = DomainClassifier()
-            >>> results = classifier.classify_by_images(["instagram.com"])
-            >>> print(f"{results[0]['domain']}: {results[0]['category']} ({results[0]['confidence']:.3f})")
+            >>> run = classifier.classify_by_images(["instagram.com"])
+            >>> result = run["results"][0]
+            >>> print(f"{result['domain']}: {result['category']} ({result['confidence']:.3f})")
             instagram.com: socialnet (0.912)
         """
         return self._run(domains, "images", archive_date, use_cache, latest)

--- a/src/piedomains/checkpoints.py
+++ b/src/piedomains/checkpoints.py
@@ -47,11 +47,8 @@ def read_sidecar(
     if Path(source).exists():
         return None  # a real local directory that simply lacks the file
 
-    # `errors` does not export this in supported Hub 0.23; `utils` does in 0.23 and 1.x.
-    from huggingface_hub import hf_hub_download  # pyright: ignore[reportMissingImports]
-    from huggingface_hub.utils import (
-        EntryNotFoundError,  # pyright: ignore[reportPrivateImportUsage]
-    )
+    from huggingface_hub import hf_hub_download
+    from huggingface_hub.errors import EntryNotFoundError
 
     try:
         path = hf_hub_download(repo_id=source, filename=filename, revision=revision)

--- a/tests/test_integration_critical.py
+++ b/tests/test_integration_critical.py
@@ -325,28 +325,20 @@ class TestCriticalIntegration(unittest.TestCase):
     @skip_in_ci()
     @pytest.mark.ml
     def test_real_model_inference_basic(self):
-        """Test actual model inference with real TensorFlow models (requires ML models)."""
-        # classify_by_text fetches the page, so this needs a browser. @skip_in_ci
-        # keeps it off CI, which installs none -- but it ran on a developer
-        # machine without them too, and failed rather than skipping while every
-        # other browser-dependent test in the suite skipped correctly.
-        from tests.conftest import browser_available
+        """Run the published PyTorch checkpoint without depending on a live page."""
+        from piedomains.text import TextClassifier
 
-        if not browser_available():
-            self.skipTest("Playwright browsers not available")
+        classifier = TextClassifier(cache_dir=self.temp_dir)
+        classifier.load_models()
+        prediction = classifier._predict_text(
+            "wikipedia encyclopedia reference articles history science education"
+        )
 
-        classifier = DomainClassifier(cache_dir=self.temp_dir)
-
-        # Test with a well-known domain that should classify successfully
-        result = classifier.classify_by_text(["google.com"])
-
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["domain"], "google.com")
-        self.assertIsInstance(result[0]["category"], str)
-        self.assertIsInstance(result[0]["confidence"], float)
-        self.assertGreater(result[0]["confidence"], 0.0)
-        self.assertLessEqual(result[0]["confidence"], 1.0)
+        self.assertIsInstance(prediction["text_label"], str)
+        self.assertIsInstance(prediction["text_prob"], float)
+        self.assertGreater(prediction["text_prob"], 0.0)
+        self.assertLessEqual(prediction["text_prob"], 1.0)
+        self.assertAlmostEqual(sum(prediction["text_domain_probs"].values()), 1.0)
 
     def test_archive_date_validation(self):
         """Test archive date validation and error handling."""

--- a/uv.lock
+++ b/uv.lock
@@ -975,7 +975,7 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.24.0"
+version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -988,9 +988,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/9b/d3bb4e7d792835daf34dd7091bbc7d7b4e0437d9388f1ea7239cce49f478/huggingface_hub-1.24.0.tar.gz", hash = "sha256:18431ff4daae0749aa9ba102fc952e314c98e1d30ebdec5319d85ca0a83e1ae5", size = 921848, upload-time = "2026-07-17T09:54:01.022Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/9b/ddf3d02a8681f1b9ce52fda03d755dad6b74c4f8172304c4c8d2975450f9/huggingface_hub-1.27.0.tar.gz", hash = "sha256:c1fed40ea82a6b41b477f5243546549b792ae0a93abcea608cff66089bf8f8df", size = 942668, upload-time = "2026-08-07T12:48:05.161Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/c3/aeaaf3911d2529614be18d1c8b5496afc185560e76568063d517283318af/huggingface_hub-1.24.0-py3-none-any.whl", hash = "sha256:6ed4120a84a6beec900640aa7e346bd766a6b7341e41526fef5dc8bd81fb7d59", size = 771904, upload-time = "2026-07-17T09:53:59.106Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d8/95b735e183957c1f26d94c52977f09d466d55119cbbc1558ea4975e4c216/huggingface_hub-1.27.0-py3-none-any.whl", hash = "sha256:7df6827c2f956c60fbaa64646e979e566db76f619dd0a9729dfb8c5a3eb4f68d", size = 784926, upload-time = "2026-08-07T12:48:02.905Z" },
 ]
 
 [[package]]
@@ -2030,7 +2030,7 @@ train = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.8.0" },
     { name = "beautifulsoup4", specifier = ">=4.10.0" },
-    { name = "huggingface-hub", specifier = ">=0.23" },
+    { name = "huggingface-hub", specifier = ">=1.27.0" },
     { name = "litellm", specifier = ">=1.55.0" },
     { name = "nltk", specifier = ">=3.8" },
     { name = "numpy", specifier = ">=1.24.0" },


### PR DESCRIPTION
Summary:
- require Hugging Face Hub 1.27.0 and use its documented errors API
- remove the old 0.23 compatibility shim and Pyright ignores
- make the real-model smoke deterministic and align API examples with the run envelope
- ignore generated Sphinx build output

Validation:
- default suite: 398 passed, 1 skipped
- real published-checkpoint smoke: passed
- Ruff, Pyright, pydoclint, deptry, and lock check: passed
- Sphinx HTML and doctest builds with warnings as errors: passed