### PR TITLE
Close the WARC record buffer the test fixture leaves open

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,9 +120,13 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+log_level = "INFO"
+xfail_strict = true
+filterwarnings = ["error"]
 addopts = [
     "-ra",
     "--strict-markers",
+    "--strict-config",
     "-m",
     "not live and not archive and not ml and not slow",
 ]

--- a/tests/test_commoncrawl.py
+++ b/tests/test_commoncrawl.py
@@ -30,16 +30,20 @@ def warc_bytes(url="https://example.com/", body=b"<html><body>hello</body></html
 
     buffer = io.BytesIO()
     writer = WARCWriter(buffer, gzip=True)
-    writer.write_record(
-        writer.create_warc_record(
-            url,
-            "response",
-            payload=io.BytesIO(body),
-            http_headers=StatusAndHeaders(
-                "200 OK", [("Content-Type", "text/html")], protocol="HTTP/1.1"
-            ),
-        )
+    record = writer.create_warc_record(
+        url,
+        "response",
+        payload=io.BytesIO(body),
+        http_headers=StatusAndHeaders(
+            "200 OK", [("Content-Type", "text/html")], protocol="HTTP/1.1"
+        ),
     )
+    try:
+        writer.write_record(record)
+    finally:
+        # create_warc_record buffers the payload in a SpooledTemporaryFile
+        # that write_record does not close.
+        record.raw_stream.close()
     return buffer.getvalue()
 
 


### PR DESCRIPTION
`filterwarnings = ["error"]` failed both record-parsing tests on an unclosed `tempfile.SpooledTemporaryFile`.

warcio's `create_warc_record` buffers the payload in one and `write_record` does not close it:

```python
rec = w.create_warc_record(...)
# raw_stream: <class 'tempfile.SpooledTemporaryFile'>
w.write_record(rec)
# after write, raw_stream closed? False
```

So `warc_bytes()` leaked a temp file per record it built.

The leak is in the **test helper, not in `commoncrawl.py`**. My first guess was the `for entry in ArchiveIterator(...)` with an early `return`, which abandons the iterator — I wrapped it in `contextlib.closing` and then checked whether that was doing any work. It wasn't: the tests drive that exact path and pass without it, so I dropped the change rather than keep speculative cleanup in the parsing code.

Also picks up py-canon 1.3.0's strict pytest settings (PP302–PP309), which is what surfaced this. The `addopts` list is reflowed back to one entry per line — the `-m` flag and its value have to stay adjacent, and that is easier to see multi-line.

`394 passed, 5 skipped, 690 subtests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SkMDqnEFUgr7Mbc1HwMqX