### PR TITLE
Ignore the unfixable nltk advisory in preen's audit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,6 +225,12 @@ link_ignore = [
     "//spaces",
 ]
 
+# GHSA-8mgp-746c-j5xp names nltk 3.10.3, the current release, with no patched
+# version: model-artifact loading can touch files outside allowed roots. This
+# package only downloads the standard corpora and never loads model artifacts.
+# Remove once nltk ships a fix (preen reports the ignored id as info until then).
+audit_ignore = ["GHSA-8mgp-746c-j5xp"]
+
 [dependency-groups]
 # PEP 735 groups, not extras: these are development concerns, and the reusable
 # CI wheel job installs `--group test` against the built wheel.


### PR DESCRIPTION
main has been red on preen's audit since the 8 September scheduled run: `nltk 3.10.3 has known vulnerabilities: PYSEC-2026-3740`. nltk 3.10.3 is the newest release and the advisory (GHSA-8mgp-746c-j5xp) lists no patched version, so there is nothing to bump to. It concerns model-artifact loading escaping allowed roots; this package only downloads the standard corpora.

Adds `[tool.preen] audit_ignore = ["GHSA-8mgp-746c-j5xp"]`. The option ships in preen 0.6.1 (gojiplus/preen#91); until that is on PyPI the key is ignored and this PR's lint stays red, then auto-merge lands it. preen keeps reporting the ignored id as info so the exception stays visible; drop the entry when nltk ships a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSrN6M7sRy2pVNDdCzU49Z
