### PR TITLE
Ignore the unfixable accelerate advisory in preen's audit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,7 +229,12 @@ link_ignore = [
 # version: model-artifact loading can touch files outside allowed roots. This
 # package only downloads the standard corpora and never loads model artifacts.
 # Remove once nltk ships a fix (preen reports the ignored id as info until then).
-audit_ignore = ["GHSA-8mgp-746c-j5xp"]
+#
+# GHSA-4j2p-28q2-5m79 names accelerate 1.14.0, also the current release with no
+# patched version: load_checkpoint_in_model trusts weight_map paths in a sharded
+# checkpoint index. accelerate is in the train group only, never imported by the
+# package, and training loads checkpoints this repo wrote itself.
+audit_ignore = ["GHSA-8mgp-746c-j5xp", "GHSA-4j2p-28q2-5m79"]
 
 [dependency-groups]
 # PEP 735 groups, not extras: these are development concerns, and the reusable


### PR DESCRIPTION
Second unfixable advisory on main, surfaced by the same run as the nltk one: `accelerate 1.14.0 has known vulnerabilities: CVE-2026-69112` (GHSA-4j2p-28q2-5m79). 1.14.0 is the newest release and the advisory lists no patched version. It concerns `load_checkpoint_in_model` trusting `weight_map` paths in a sharded checkpoint index. accelerate is in the `train` group only, the package never imports it, and training loads checkpoints this repo wrote itself.

Adds the id to `[tool.preen] audit_ignore` next to the nltk entry. Inert until preen 0.6.1 ships the option; lint stays red until then. Both entries leave when upstream ships fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSrN6M7sRy2pVNDdCzU49Z
